### PR TITLE
[T-70] - Added decoding from Base64

### DIFF
--- a/compiler/src/file/file.router.ts
+++ b/compiler/src/file/file.router.ts
@@ -18,12 +18,16 @@ const execShellCommand = (cmd: string) => {
 
 const fileRouter = express.Router();
 
+
+const decodeBase64 = (data: string) => {
+  return Buffer.from(data, 'base64').toString('ascii');
+}
+
 fileRouter.post("/", async (req: Request, res: Response) => {
   const fileContent: string = req.body.content;
-  console.log("BODY", req.body);
   try {
-    fs.outputFile("../files/code.js", fileContent);
-  } catch (error) {
+    fs.outputFile("../files/code.js", decodeBase64(fileContent));
+  } catch (error) { 
     return res.status(500).send(error);
   }
   try {


### PR DESCRIPTION
### Context

To be able to have spaces and returns inside of our executable code written inside the editor, we decided to encode it in Base64 before sending it to the backend as to preserve its initial state.

This meant that we had to decode the output before writing it to a file.

### Solution

- Added a decode function to resolve Base64 encoded text.
- Decode the received text before writing it as a file.

### Todo

/